### PR TITLE
fix tail_test for systems without $TMPDIR.

### DIFF
--- a/tail_test.go
+++ b/tail_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 	"time"
 )
@@ -23,7 +24,7 @@ var line = "{\"_file\":{\"Type\":0,\"Treatment\":0,\"Value\":\"solr.txt\"},\"_gr
 func _tail_init() {
 	StandardTimeProvider = new(FixedTimeProvider)
 	output = make(chan Record, 100)
-	offsetFile = os.TempDir() + "test.txt"
+	offsetFile = path.Join(os.TempDir(), "test.txt")
 	_ = os.Remove(offsetFile)
 	parser = NewRegexpParser("host.local", "foo", "solr.txt", output, "(?P<line>.+)\n", nil, 32768)
 	tail = NewTail(parser, -1, "testdata/solr.txt", offsetFile, 0)


### PR DESCRIPTION
Tests were failing on my Lubuntu netbook; with this change they all pass.
